### PR TITLE
Fix sensors page

### DIFF
--- a/services/react-client/src/components/sensor/SensorPage.jsx
+++ b/services/react-client/src/components/sensor/SensorPage.jsx
@@ -11,6 +11,7 @@ import * as sensorActions from '../../actions/sensor'
 export class SensorPage extends React.Component {
   static propTypes = {
     history: PropTypes.object.isRequired,
+    match: PropTypes.object.isRequired,
     site: PropTypes.object.isRequired,
     sensors: PropTypes.array.isRequired,
     actions: PropTypes.object.isRequired,
@@ -36,8 +37,9 @@ export class SensorPage extends React.Component {
   }
 
   componentDidMount () {
-    const { site, actions } = this.props
-    actions.getSiteSensors(site.id)
+    const { actions } = this.props
+    const siteId = this.props.match.params.id
+    actions.getSiteSensors(siteId)
   }
 
   render () {
@@ -66,7 +68,7 @@ export class SensorPage extends React.Component {
 export function mapStateToProps (state, ownProps) {
   const siteId = ownProps.match.params.id
   return {
-    site: state.site.items.find(site => site.id === siteId),
+    site: state.site.items.find(site => site.id === siteId) || {},
     sensors: state.sensor.items.filter(sensor => sensor.siteId === siteId)
   }
 }

--- a/services/react-client/src/components/sensor/__tests__/SensorPage.test.js
+++ b/services/react-client/src/components/sensor/__tests__/SensorPage.test.js
@@ -10,6 +10,7 @@ describe('SensorPage', () => {
     let nextProps, nextState
     const props = {
       history: {},
+      match: { params: {} },
       site: {},
       sensors: [],
       actions: {}
@@ -21,6 +22,7 @@ describe('SensorPage', () => {
     })
 
     test('renders connected react component with props', () => {
+      props.match.params.id = '1111-1111'
       props.site = { id: '1111-1111', name: 'Station 1', location: 'Toronto, ON', priority: 2, tags: [ 'oxygen', 'hydrogen' ] }
       props.sensors = [
         { id: 'aaaa-aaaa', siteId: '1111-1111', name: 'temperature', unit: 'celsius', minSafe: -30, maxSafe: 30 }
@@ -39,6 +41,7 @@ describe('SensorPage', () => {
       expect(props.history.goBack).toHaveBeenCalled()
     })
     test('renders connected react component with props', () => {
+      props.match.params.id = '2222-2222'
       props.sites = { id: '2222-2222', name: 'Station 2', location: 'Kingston, ON', priority: 3, tags: [ 'gold', 'silver' ] }
       props.sensors = [
         { id: 'bbbb-bbbb', siteId: '2222-2222', name: 'temperature', unit: 'fahrenheit', minSafe: -22, maxSafe: 86 }


### PR DESCRIPTION
This PR fixes `sensors` page. So if you hit directly `/sensors/:sensorId`, you will see the page loaded correctly.