### PR TITLE
Graphql to asset service

### DIFF
--- a/services/graphql-server/README.md
+++ b/services/graphql-server/README.md
@@ -49,11 +49,11 @@
 
   **Apollo**
   - https://www.apollographql.com/engine
+  - https://github.com/apollographql/graphql-tools
+    - https://www.apollographql.com/docs/graphql-tools
   - https://github.com/apollographql/apollo-server
     - https://www.apollographql.com/docs/apollo-server
       - https://www.apollographql.com/docs/apollo-server/features/unions-interfaces.html
-  - https://github.com/apollographql/graphql-tools
-    - https://www.apollographql.com/docs/graphql-tools
   - https://github.com/apollographql/apollo-client
     - https://www.apollographql.com/client
 

--- a/services/graphql-server/package.json
+++ b/services/graphql-server/package.json
@@ -33,6 +33,7 @@
     "nats": "^1.0.1",
     "opentracing": "^0.14.3",
     "prom-client": "^11.1.3",
+    "uuid": "^3.3.2",
     "winston": "^3.1.0"
   },
   "devDependencies": {

--- a/services/graphql-server/src/graphql/resolvers/asset.js
+++ b/services/graphql-server/src/graphql/resolvers/asset.js
@@ -3,7 +3,10 @@ const resolvers = {
     async asset (_, { id }, context, info) {
       try {
         const ctx = { span: context.span }
-        return await context.assetService.getAsset(ctx, id)
+        const getAlarm = context.assetService.getAlarm(ctx, id)
+        const getCamera = context.assetService.getCamera(ctx, id)
+        const [ alarm, camera ] = await Promise.all([ getAlarm, getCamera ])
+        return alarm || camera
       } catch (err) {
         context.logger.error('Error on asset:', err)
         throw err
@@ -13,7 +16,10 @@ const resolvers = {
     async assets (_, { siteId }, context, info) {
       try {
         const ctx = { span: context.span }
-        return await context.assetService.getAssets(ctx, siteId)
+        const allAlarm = context.assetService.allAlarm(ctx, siteId)
+        const allCamera = context.assetService.allCamera(ctx, siteId)
+        const [ alarms, cameras ] = await Promise.all([ allAlarm, allCamera ])
+        return [].concat(alarms, cameras)
       } catch (err) {
         context.logger.error('Error on assets:', err)
         throw err
@@ -35,7 +41,8 @@ const resolvers = {
     async updateAlarm (_, { id, input }, context, info) {
       try {
         const ctx = { span: context.span }
-        return await context.assetService.updateAlarm(ctx, id, input)
+        const updated = await context.assetService.updateAlarm(ctx, id, input)
+        return updated ? await context.assetService.getAlarm(ctx, id) : null
       } catch (err) {
         context.logger.error('Error on updateAlarm:', err)
         throw err
@@ -55,7 +62,8 @@ const resolvers = {
     async updateCamera (_, { id, input }, context, info) {
       try {
         const ctx = { span: context.span }
-        return await context.assetService.updateCamera(ctx, id, input)
+        const updated = await context.assetService.updateCamera(ctx, id, input)
+        return updated ? await context.assetService.getCamera(ctx, id) : null
       } catch (err) {
         context.logger.error('Error on updateCamera:', err)
         throw err
@@ -65,7 +73,10 @@ const resolvers = {
     async deleteAsset (_, { id }, context, info) {
       try {
         const ctx = { span: context.span }
-        return await context.assetService.deleteAsset(ctx, id)
+        let deleteAlarm = context.assetService.deleteAlarm(ctx, id)
+        let deleteCamera = context.assetService.deleteCamera(ctx, id)
+        const [ alarmDeleted, cameraDeleted ] = await Promise.all([ deleteAlarm, deleteCamera ])
+        return alarmDeleted || cameraDeleted
       } catch (err) {
         context.logger.error('Error on deleteAsset:', err)
         throw err

--- a/services/graphql-server/src/graphql/resolvers/asset.js
+++ b/services/graphql-server/src/graphql/resolvers/asset.js
@@ -1,0 +1,103 @@
+const resolvers = {
+  Query: {
+    async asset (_, { id }, context, info) {
+      try {
+        const ctx = { span: context.span }
+        return await context.assetService.getAsset(ctx, id)
+      } catch (err) {
+        context.logger.error('Error on asset:', err)
+        throw err
+      }
+    },
+
+    async assets (_, { siteId }, context, info) {
+      try {
+        const ctx = { span: context.span }
+        return await context.assetService.getAssets(ctx, siteId)
+      } catch (err) {
+        context.logger.error('Error on assets:', err)
+        throw err
+      }
+    }
+  },
+
+  Mutation: {
+    async createAlarm (_, { input }, context, info) {
+      try {
+        const ctx = { span: context.span }
+        return await context.assetService.createAlarm(ctx, input)
+      } catch (err) {
+        context.logger.error('Error on createAlarm:', err)
+        throw err
+      }
+    },
+
+    async updateAlarm (_, { id, input }, context, info) {
+      try {
+        const ctx = { span: context.span }
+        return await context.assetService.updateAlarm(ctx, id, input)
+      } catch (err) {
+        context.logger.error('Error on updateAlarm:', err)
+        throw err
+      }
+    },
+
+    async createCamera (_, { input }, context, info) {
+      try {
+        const ctx = { span: context.span }
+        return await context.assetService.createCamera(ctx, input)
+      } catch (err) {
+        context.logger.error('Error on createCamera:', err)
+        throw err
+      }
+    },
+
+    async updateCamera (_, { id, input }, context, info) {
+      try {
+        const ctx = { span: context.span }
+        return await context.assetService.updateCamera(ctx, id, input)
+      } catch (err) {
+        context.logger.error('Error on updateCamera:', err)
+        throw err
+      }
+    },
+
+    async deleteAsset (_, { id }, context, info) {
+      try {
+        const ctx = { span: context.span }
+        return await context.assetService.deleteAsset(ctx, id)
+      } catch (err) {
+        context.logger.error('Error on deleteAsset:', err)
+        throw err
+      }
+    }
+  },
+
+  Asset: {
+    __resolveType (obj, context, info) {
+      if (obj.material) {
+        return 'Alarm'
+      }
+      if (obj.resolution) {
+        return 'Camera'
+      }
+      return null
+    }
+  },
+
+  Alarm: {
+    id: alarm => alarm.id,
+    siteId: alarm => alarm.siteId,
+    serialNo: alarm => alarm.serialNo,
+    material: alarm => alarm.material
+  },
+
+  Camera: {
+    id: camera => camera.id,
+    siteId: camera => camera.siteId,
+    serialNo: camera => camera.serialNo,
+    resolution: camera => camera.resolution
+  }
+}
+
+module.exports = resolvers

--- a/services/graphql-server/src/graphql/resolvers/asset.test.js
+++ b/services/graphql-server/src/graphql/resolvers/asset.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
-require('should')
 const sinon = require('sinon')
+const should = require('should')
 
 const resolvers = require('./asset')
 
@@ -21,13 +21,16 @@ describe('assetResolvers', () => {
     }
 
     assetService = {
-      getAsset () {},
-      getAssets () {},
       createAlarm () {},
+      allAlarm () {},
+      getAlarm () {},
       updateAlarm () {},
+      deleteAlarm () {},
       createCamera () {},
+      allCamera () {},
+      getCamera () {},
       updateCamera () {},
-      deleteAsset () {}
+      deleteCamera () {}
     }
     _assetService = sinon.mock(assetService)
 
@@ -43,32 +46,55 @@ describe('assetResolvers', () => {
     let id
 
     describe('asset', () => {
-      it('should reject with an error when service request fails', done => {
+      it('should reject with error when both get requests fail', done => {
         id = 'aaaa-aaaa'
         const err = new Error('get error')
-        _assetService.expects('getAsset').withArgs({ span: context.span }, id).rejects(err)
+        _assetService.expects('getAlarm').withArgs({ span: context.span }, id).rejects(err)
+        _assetService.expects('getCamera').withArgs({ span: context.span }, id).rejects(err)
         resolvers.Query.asset(null, { id }, context, info).catch(e => {
           e.should.eql(err)
           _assetService.verify()
           done()
         })
       })
-      it('should resolve with an alarm when asset is an alarm', done => {
+      it('should reject with error when get alarm request fails', done => {
         id = 'aaaa-aaaa'
-        const asset = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
-        _assetService.expects('getAsset').withArgs({ span: context.span }, id).resolves(asset)
+        const err = new Error('get alarm error')
+        _assetService.expects('getAlarm').withArgs({ span: context.span }, id).rejects(err)
+        resolvers.Query.asset(null, { id }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should reject with error when get camera request fails', done => {
+        id = 'aaaa-aaaa'
+        const err = new Error('get camera error')
+        _assetService.expects('getCamera').withArgs({ span: context.span }, id).rejects(err)
+        resolvers.Query.asset(null, { id }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with alarm when asset is alarm', done => {
+        id = 'aaaa-aaaa'
+        const alarm = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'co' }
+        _assetService.expects('getAlarm').withArgs({ span: context.span }, id).resolves(alarm)
+        _assetService.expects('getCamera').withArgs({ span: context.span }, id).resolves(null)
         resolvers.Query.asset(null, { id }, context, info).then(result => {
-          result.should.eql(asset)
+          result.should.eql(alarm)
           _assetService.verify()
           done()
         }).catch(done)
       })
-      it('should resolve with a camera when asset is a camera', done => {
+      it('should resolve with camera when asset is camera', done => {
         id = 'bbbb-bbbb'
-        const asset = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
-        _assetService.expects('getAsset').withArgs({ span: context.span }, id).resolves(asset)
+        const camera = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+        _assetService.expects('getAlarm').withArgs({ span: context.span }, id).resolves(null)
+        _assetService.expects('getCamera').withArgs({ span: context.span }, id).resolves(camera)
         resolvers.Query.asset(null, { id }, context, info).then(result => {
-          result.should.eql(asset)
+          result.should.eql(camera)
           _assetService.verify()
           done()
         }).catch(done)
@@ -78,25 +104,45 @@ describe('assetResolvers', () => {
     describe('assets', () => {
       let siteId
 
-      it('should reject with an error when service request fails', done => {
+      it('should reject with error when both all requests fail', done => {
         siteId = '1111-1111'
         const err = new Error('all error')
-        _assetService.expects('getAssets').withArgs({ span: context.span }, siteId).rejects(err)
+        _assetService.expects('allAlarm').withArgs({ span: context.span }, siteId).rejects(err)
+        _assetService.expects('allCamera').withArgs({ span: context.span }, siteId).rejects(err)
         resolvers.Query.assets(null, { siteId }, context, info).catch(e => {
           e.should.eql(err)
           _assetService.verify()
           done()
         })
       })
-      it('should resolve with an array of alarms and cameras', done => {
+      it('should reject with error when all alarm request fails', done => {
         siteId = '1111-1111'
-        const assets = [
-          { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' },
-          { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
-        ]
-        _assetService.expects('getAssets').withArgs({ span: context.span }, siteId).resolves(assets)
-        resolvers.Query.assets(null, { siteId }, context, info).then(result => {
-          result.should.eql(assets)
+        const err = new Error('all alarm error')
+        _assetService.expects('allAlarm').withArgs({ span: context.span }, siteId).rejects(err)
+        resolvers.Query.assets(null, { siteId }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should reject with error when all camera request fails', done => {
+        siteId = '1111-1111'
+        const err = new Error('all camera error')
+        _assetService.expects('allCamera').withArgs({ span: context.span }, siteId).rejects(err)
+        resolvers.Query.assets(null, { siteId }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with array of alarms and cameras when both requests succeeds', done => {
+        siteId = '1111-1111'
+        const alarms = [{ id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'co' }]
+        const cameras = [{ id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }]
+        _assetService.expects('allAlarm').withArgs({ span: context.span }, siteId).resolves(alarms)
+        _assetService.expects('allCamera').withArgs({ span: context.span }, siteId).resolves(cameras)
+        resolvers.Query.assets(null, { siteId }, context, info).then(assets => {
+          assets.should.eql([ alarms[0], cameras[0] ])
           _assetService.verify()
           done()
         }).catch(done)
@@ -108,7 +154,7 @@ describe('assetResolvers', () => {
     describe('createAlarm', () => {
       let input
 
-      it('should reject with an error when service request fails', done => {
+      it('should reject with error when service request fails', done => {
         input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
         const err = new Error('create alarm error')
         _assetService.expects('createAlarm').withArgs({ span: context.span }, input).rejects(err)
@@ -118,7 +164,7 @@ describe('assetResolvers', () => {
           done()
         })
       })
-      it('should resolve with an alarm when service request succeeds', done => {
+      it('should resolve with alarm when service request succeeds', done => {
         input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
         const alarm = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
         _assetService.expects('createAlarm').withArgs({ span: context.span }, input).resolves(alarm)
@@ -133,7 +179,7 @@ describe('assetResolvers', () => {
     describe('updateAlarm', () => {
       let id, input
 
-      it('should reject with an error when service request fails', done => {
+      it('should reject with error when update request fails', done => {
         id = 'aaaa-aaaa'
         input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
         const err = new Error('update alarm error')
@@ -144,11 +190,34 @@ describe('assetResolvers', () => {
           done()
         })
       })
-      it('should resolve with an alarm when service request succeeds', done => {
+      it('should reject with error when get request fails', done => {
+        id = 'aaaa-aaaa'
+        input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+        const err = new Error('get alarm error')
+        _assetService.expects('updateAlarm').withArgs({ span: context.span }, id, input).resolves(true)
+        _assetService.expects('getAlarm').withArgs({ span: context.span }, id).rejects(err)
+        resolvers.Mutation.updateAlarm(null, { id, input }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with null when update request resolves with false', done => {
+        id = 'aaaa-aaaa'
+        input = { siteId: '1111-1111', serialNo: '1001', material: 'co' }
+        _assetService.expects('updateAlarm').withArgs({ span: context.span }, id, input).resolves(false)
+        resolvers.Mutation.updateAlarm(null, { id, input }, context, info).then(result => {
+          should.not.exist(result)
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+      it('should resolve with alarm when service requests succeeds', done => {
         id = 'aaaa-aaaa'
         input = { siteId: '1111-1111', serialNo: '1001', material: 'co' }
         const alarm = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'co' }
-        _assetService.expects('updateAlarm').withArgs({ span: context.span }, id, input).resolves(alarm)
+        _assetService.expects('updateAlarm').withArgs({ span: context.span }, id, input).resolves(true)
+        _assetService.expects('getAlarm').withArgs({ span: context.span }, id).resolves(alarm)
         resolvers.Mutation.updateAlarm(null, { id, input }, context, info).then(result => {
           result.should.eql(alarm)
           _assetService.verify()
@@ -160,7 +229,7 @@ describe('assetResolvers', () => {
     describe('createCamera', () => {
       let input
 
-      it('should reject with an error when service request fails', done => {
+      it('should reject with error when service request fails', done => {
         input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
         const err = new Error('create camera error')
         _assetService.expects('createCamera').withArgs({ span: context.span }, input).rejects(err)
@@ -170,7 +239,7 @@ describe('assetResolvers', () => {
           done()
         })
       })
-      it('should resolve with a camera when service request succeeds', done => {
+      it('should resolve with camera when service request succeeds', done => {
         input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
         const camera = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
         _assetService.expects('createCamera').withArgs({ span: context.span }, input).resolves(camera)
@@ -185,7 +254,7 @@ describe('assetResolvers', () => {
     describe('updateCamera', () => {
       let id, input
 
-      it('should reject with an error when service request fails', done => {
+      it('should reject with error when update request fails', done => {
         id = 'bbbb-bbbb'
         input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
         const err = new Error('update camera error')
@@ -196,11 +265,34 @@ describe('assetResolvers', () => {
           done()
         })
       })
-      it('should resolve with a camera when service request succeeds', done => {
+      it('should reject with error when get request fails', done => {
+        id = 'bbbb-bbbb'
+        input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+        const err = new Error('update camera error')
+        _assetService.expects('updateCamera').withArgs({ span: context.span }, id, input).resolves(true)
+        _assetService.expects('getCamera').withArgs({ span: context.span }, id).rejects(err)
+        resolvers.Mutation.updateCamera(null, { id, input }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with null when update request resolves with false', done => {
+        id = 'bbbb-bbbb'
+        input = { siteId: '1111-1111', serialNo: '2001', resolution: 1920000 }
+        _assetService.expects('updateCamera').withArgs({ span: context.span }, id, input).resolves(false)
+        resolvers.Mutation.updateCamera(null, { id, input }, context, info).then(result => {
+          should.not.exist(result)
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+      it('should resolve with camera when service request succeeds', done => {
         id = 'bbbb-bbbb'
         input = { siteId: '1111-1111', serialNo: '2001', resolution: 1920000 }
         const camera = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 1920000 }
-        _assetService.expects('updateCamera').withArgs({ span: context.span }, id, input).resolves(camera)
+        _assetService.expects('updateCamera').withArgs({ span: context.span }, id, input).resolves(true)
+        _assetService.expects('getCamera').withArgs({ span: context.span }, id).resolves(camera)
         resolvers.Mutation.updateCamera(null, { id, input }, context, info).then(result => {
           result.should.eql(camera)
           _assetService.verify()
@@ -212,19 +304,61 @@ describe('assetResolvers', () => {
     describe('deleteAsset', () => {
       let id
 
-      it('should reject with an error when service request fails', done => {
+      it('should reject with an error when both delete requests fail', done => {
         id = 'aaaa-aaaa'
-        const err = new Error('delete asset error')
-        _assetService.expects('deleteAsset').withArgs({ span: context.span }, id).rejects(err)
+        const err = new Error('delete error')
+        _assetService.expects('deleteAlarm').withArgs({ span: context.span }, id).rejects(err)
+        _assetService.expects('deleteCamera').withArgs({ span: context.span }, id).rejects(err)
         resolvers.Mutation.deleteAsset(null, { id }, context, info).catch(e => {
           e.should.eql(err)
           _assetService.verify()
           done()
         })
       })
-      it('should resolve with true when service request succeeds', done => {
+      it('should reject with an error when alarm delete request fails', done => {
+        id = 'aaaa-aaaa'
+        const err = new Error('delete alarm error')
+        _assetService.expects('deleteAlarm').withArgs({ span: context.span }, id).rejects(err)
+        resolvers.Mutation.deleteAsset(null, { id }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should reject with an error when camera delete request fails', done => {
+        id = 'aaaa-aaaa'
+        const err = new Error('delete camera error')
+        _assetService.expects('deleteCamera').withArgs({ span: context.span }, id).rejects(err)
+        resolvers.Mutation.deleteAsset(null, { id }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with false when both delete requests resolve with false', done => {
+        id = 'aaaa-aaaa'
+        _assetService.expects('deleteAlarm').withArgs({ span: context.span }, id).resolves(false)
+        _assetService.expects('deleteCamera').withArgs({ span: context.span }, id).resolves(false)
+        resolvers.Mutation.deleteAsset(null, { id }, context, info).then(result => {
+          result.should.be.false()
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+      it('should resolve with true when delete alarm request resolves with true', done => {
+        id = 'aaaa-aaaa'
+        _assetService.expects('deleteAlarm').withArgs({ span: context.span }, id).resolves(true)
+        _assetService.expects('deleteCamera').withArgs({ span: context.span }, id).resolves(false)
+        resolvers.Mutation.deleteAsset(null, { id }, context, info).then(result => {
+          result.should.be.true()
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+      it('should resolve with true when delete camera request resolves with true', done => {
         id = 'bbbb-bbbb'
-        _assetService.expects('deleteAsset').withArgs({ span: context.span }, id).resolves(true)
+        _assetService.expects('deleteAlarm').withArgs({ span: context.span }, id).resolves(false)
+        _assetService.expects('deleteCamera').withArgs({ span: context.span }, id).resolves(true)
         resolvers.Mutation.deleteAsset(null, { id }, context, info).then(result => {
           result.should.be.true()
           _assetService.verify()

--- a/services/graphql-server/src/graphql/resolvers/asset.test.js
+++ b/services/graphql-server/src/graphql/resolvers/asset.test.js
@@ -1,0 +1,298 @@
+/* eslint-env mocha */
+require('should')
+const sinon = require('sinon')
+
+const resolvers = require('./asset')
+
+describe('assetResolvers', () => {
+  let span, logger
+  let assetService, _assetService
+  let context, info
+
+  beforeEach(() => {
+    span = {}
+    logger = {
+      debug () {},
+      verbose () {},
+      info () {},
+      warn () {},
+      error () {},
+      fatal () {}
+    }
+
+    assetService = {
+      getAsset () {},
+      getAssets () {},
+      createAlarm () {},
+      updateAlarm () {},
+      createCamera () {},
+      updateCamera () {},
+      deleteAsset () {}
+    }
+    _assetService = sinon.mock(assetService)
+
+    context = { span, logger, assetService }
+    info = {}
+  })
+
+  afterEach(() => {
+    _assetService.restore()
+  })
+
+  describe('Query', () => {
+    let id
+
+    describe('asset', () => {
+      it('should reject with an error when service request fails', done => {
+        id = 'aaaa-aaaa'
+        const err = new Error('get error')
+        _assetService.expects('getAsset').withArgs({ span: context.span }, id).rejects(err)
+        resolvers.Query.asset(null, { id }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with an alarm when asset is an alarm', done => {
+        id = 'aaaa-aaaa'
+        const asset = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+        _assetService.expects('getAsset').withArgs({ span: context.span }, id).resolves(asset)
+        resolvers.Query.asset(null, { id }, context, info).then(result => {
+          result.should.eql(asset)
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+      it('should resolve with a camera when asset is a camera', done => {
+        id = 'bbbb-bbbb'
+        const asset = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+        _assetService.expects('getAsset').withArgs({ span: context.span }, id).resolves(asset)
+        resolvers.Query.asset(null, { id }, context, info).then(result => {
+          result.should.eql(asset)
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+    })
+
+    describe('assets', () => {
+      let siteId
+
+      it('should reject with an error when service request fails', done => {
+        siteId = '1111-1111'
+        const err = new Error('all error')
+        _assetService.expects('getAssets').withArgs({ span: context.span }, siteId).rejects(err)
+        resolvers.Query.assets(null, { siteId }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with an array of alarms and cameras', done => {
+        siteId = '1111-1111'
+        const assets = [
+          { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' },
+          { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+        ]
+        _assetService.expects('getAssets').withArgs({ span: context.span }, siteId).resolves(assets)
+        resolvers.Query.assets(null, { siteId }, context, info).then(result => {
+          result.should.eql(assets)
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+    })
+  })
+
+  describe('Mutation', () => {
+    describe('createAlarm', () => {
+      let input
+
+      it('should reject with an error when service request fails', done => {
+        input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+        const err = new Error('create alarm error')
+        _assetService.expects('createAlarm').withArgs({ span: context.span }, input).rejects(err)
+        resolvers.Mutation.createAlarm(null, { input }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with an alarm when service request succeeds', done => {
+        input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+        const alarm = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+        _assetService.expects('createAlarm').withArgs({ span: context.span }, input).resolves(alarm)
+        resolvers.Mutation.createAlarm(null, { input }, context, info).then(result => {
+          result.should.eql(alarm)
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+    })
+
+    describe('updateAlarm', () => {
+      let id, input
+
+      it('should reject with an error when service request fails', done => {
+        id = 'aaaa-aaaa'
+        input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+        const err = new Error('update alarm error')
+        _assetService.expects('updateAlarm').withArgs({ span: context.span }, id, input).rejects(err)
+        resolvers.Mutation.updateAlarm(null, { id, input }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with an alarm when service request succeeds', done => {
+        id = 'aaaa-aaaa'
+        input = { siteId: '1111-1111', serialNo: '1001', material: 'co' }
+        const alarm = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'co' }
+        _assetService.expects('updateAlarm').withArgs({ span: context.span }, id, input).resolves(alarm)
+        resolvers.Mutation.updateAlarm(null, { id, input }, context, info).then(result => {
+          result.should.eql(alarm)
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+    })
+
+    describe('createCamera', () => {
+      let input
+
+      it('should reject with an error when service request fails', done => {
+        input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+        const err = new Error('create camera error')
+        _assetService.expects('createCamera').withArgs({ span: context.span }, input).rejects(err)
+        resolvers.Mutation.createCamera(null, { input }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with a camera when service request succeeds', done => {
+        input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+        const camera = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+        _assetService.expects('createCamera').withArgs({ span: context.span }, input).resolves(camera)
+        resolvers.Mutation.createCamera(null, { input }, context, info).then(result => {
+          result.should.eql(camera)
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+    })
+
+    describe('updateCamera', () => {
+      let id, input
+
+      it('should reject with an error when service request fails', done => {
+        id = 'bbbb-bbbb'
+        input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+        const err = new Error('update camera error')
+        _assetService.expects('updateCamera').withArgs({ span: context.span }, id, input).rejects(err)
+        resolvers.Mutation.updateCamera(null, { id, input }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with a camera when service request succeeds', done => {
+        id = 'bbbb-bbbb'
+        input = { siteId: '1111-1111', serialNo: '2001', resolution: 1920000 }
+        const camera = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 1920000 }
+        _assetService.expects('updateCamera').withArgs({ span: context.span }, id, input).resolves(camera)
+        resolvers.Mutation.updateCamera(null, { id, input }, context, info).then(result => {
+          result.should.eql(camera)
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+    })
+
+    describe('deleteAsset', () => {
+      let id
+
+      it('should reject with an error when service request fails', done => {
+        id = 'aaaa-aaaa'
+        const err = new Error('delete asset error')
+        _assetService.expects('deleteAsset').withArgs({ span: context.span }, id).rejects(err)
+        resolvers.Mutation.deleteAsset(null, { id }, context, info).catch(e => {
+          e.should.eql(err)
+          _assetService.verify()
+          done()
+        })
+      })
+      it('should resolve with true when service request succeeds', done => {
+        id = 'bbbb-bbbb'
+        _assetService.expects('deleteAsset').withArgs({ span: context.span }, id).resolves(true)
+        resolvers.Mutation.deleteAsset(null, { id }, context, info).then(result => {
+          result.should.be.true()
+          _assetService.verify()
+          done()
+        }).catch(done)
+      })
+    })
+  })
+
+  describe('Asset', () => {
+    describe('resolveType', () => {
+      let obj, context, info
+
+      beforeEach(() => {
+        context = null
+        info = {}
+      })
+
+      it('should return Alarm type when asset is an alarm object', () => {
+        obj = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+        resolvers.Asset.__resolveType(obj, context, info).should.equal('Alarm')
+      })
+      it('should return Camera type when asset is a camera object', () => {
+        obj = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+        resolvers.Asset.__resolveType(obj, context, info).should.equal('Camera')
+      })
+    })
+  })
+
+  describe('Alarm', () => {
+    let alarm
+
+    beforeEach(() => {
+      alarm = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+    })
+
+    it('should return id', () => {
+      resolvers.Alarm.id(alarm).should.equal(alarm.id)
+    })
+    it('should return siteId', () => {
+      resolvers.Alarm.siteId(alarm).should.equal(alarm.siteId)
+    })
+    it('should return serialNo', () => {
+      resolvers.Alarm.serialNo(alarm).should.equal(alarm.serialNo)
+    })
+    it('should return material', () => {
+      resolvers.Alarm.material(alarm).should.equal(alarm.material)
+    })
+  })
+
+  describe('Camera', () => {
+    let camera
+
+    beforeEach(() => {
+      camera = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+    })
+
+    it('should return id', () => {
+      resolvers.Camera.id(camera).should.equal(camera.id)
+    })
+    it('should return siteId', () => {
+      resolvers.Camera.siteId(camera).should.equal(camera.siteId)
+    })
+    it('should return serialNo', () => {
+      resolvers.Camera.serialNo(camera).should.equal(camera.serialNo)
+    })
+    it('should return resolution', () => {
+      resolvers.Camera.resolution(camera).should.equal(camera.resolution)
+    })
+  })
+})

--- a/services/graphql-server/src/graphql/resolvers/index.js
+++ b/services/graphql-server/src/graphql/resolvers/index.js
@@ -3,5 +3,6 @@ const _ = require('lodash')
 const siteResolvers = require('./site')
 const sensorResolvers = require('./sensor')
 const switchResolvers = require('./switch')
+const assetResolvers = require('./asset')
 
-module.exports = _.merge({}, siteResolvers, sensorResolvers, switchResolvers)
+module.exports = _.merge({}, siteResolvers, sensorResolvers, switchResolvers, assetResolvers)

--- a/services/graphql-server/src/graphql/resolvers/sensor.js
+++ b/services/graphql-server/src/graphql/resolvers/sensor.js
@@ -5,7 +5,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.sensorService.get(ctx, id)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on sensor:', err)
         throw err
       }
     },
@@ -15,7 +15,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.sensorService.all(ctx, siteId)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on sensors:', err)
         throw err
       }
     }
@@ -27,7 +27,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.sensorService.create(ctx, input)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on createSensor:', err)
         throw err
       }
     },
@@ -37,7 +37,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.sensorService.update(ctx, id, input)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on updateSensor:', err)
         throw err
       }
     },
@@ -48,7 +48,7 @@ const resolvers = {
         await context.sensorService.delete(ctx, id)
         return true
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on deleteSensor:', err)
         throw err
       }
     }

--- a/services/graphql-server/src/graphql/resolvers/site.js
+++ b/services/graphql-server/src/graphql/resolvers/site.js
@@ -69,6 +69,18 @@ const resolvers = {
     switches: (site, args, context, info) => {
       const ctx = { span: context.span }
       return context.switchService.getSwitches(ctx, site.id)
+    },
+
+    assets: async (site, args, context, info) => {
+      try {
+        const ctx = { span: context.span }
+        const allAlarm = context.assetService.allAlarm(ctx, site.id)
+        const allCamera = context.assetService.allCamera(ctx, site.id)
+        const [ alarms, cameras ] = await Promise.all([ allAlarm, allCamera ])
+        return [].concat(alarms, cameras)
+      } catch (err) {
+        throw err
+      }
     }
   }
 }

--- a/services/graphql-server/src/graphql/resolvers/site.js
+++ b/services/graphql-server/src/graphql/resolvers/site.js
@@ -5,7 +5,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.siteService.get(ctx, id)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on site:', err)
         throw err
       }
     },
@@ -15,7 +15,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.siteService.all(ctx, args)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on sites:', err)
         throw err
       }
     }
@@ -27,7 +27,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.siteService.create(ctx, input)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on createSite:', err)
         throw err
       }
     },
@@ -37,7 +37,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.siteService.update(ctx, id, input)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on updateSite:', err)
         throw err
       }
     },
@@ -48,7 +48,7 @@ const resolvers = {
         await context.siteService.delete(ctx, id)
         return true
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on deleteSite:', err)
         throw err
       }
     }

--- a/services/graphql-server/src/graphql/resolvers/switch.js
+++ b/services/graphql-server/src/graphql/resolvers/switch.js
@@ -5,7 +5,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.switchService.getSwitch(ctx, id)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on switch:', err)
         throw err
       }
     },
@@ -15,7 +15,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.switchService.getSwitches(ctx, siteId)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on switches:', err)
         throw err
       }
     }
@@ -27,7 +27,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.switchService.installSwitch(ctx, input)
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on installSwitch:', err)
         throw err
       }
     },
@@ -37,7 +37,7 @@ const resolvers = {
         const ctx = { span: context.span }
         return await context.switchService.setSwitch(ctx, id, { state })
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on setSwitch:', err)
         throw err
       }
     },
@@ -48,7 +48,7 @@ const resolvers = {
         await context.switchService.removeSwitch(ctx, id)
         return true
       } catch (err) {
-        context.logger.error(err)
+        context.logger.error('Error on removeSwitch:', err)
         throw err
       }
     }

--- a/services/graphql-server/src/graphql/router.js
+++ b/services/graphql-server/src/graphql/router.js
@@ -11,6 +11,7 @@ const Logger = require('../utils/logger')
 const SiteService = require('../services/site')
 const SensorService = require('../services/sensor')
 const SwitchService = require('../services/switch')
+const AssetService = require('../services/asset')
 
 const histogramName = 'graphql_operations_latency_seconds'
 const histogramHelp = 'latency histogram of graphql operations'
@@ -32,6 +33,7 @@ class GraphQLRouter {
    * @param {object}  options.siteService     An instance of SiteService
    * @param {object}  options.sensorService   An instance of SensorService
    * @param {object}  options.switchService   An instance of SwitchService
+   * @param {object}  options.assetService    An instance of AssetService
    */
   constructor (config, options) {
     options = options || {}
@@ -58,10 +60,11 @@ class GraphQLRouter {
 
     // Context for resolver functions
     const context = Object.assign({}, options.context, {
-      logger: options.logger || new Logger('GraphQL'),
+      logger: options.logger || new Logger('Resolvers'),
       siteService: options.siteService || new SiteService(config, options),
       sensorService: options.sensorService || new SensorService(config, options),
-      switchService: options.switchService || new SwitchService(config, options)
+      switchService: options.switchService || new SwitchService(config, options),
+      assetService: options.assetService || new AssetService(config, options)
     })
 
     // GraphQL schema

--- a/services/graphql-server/src/graphql/router.test.js
+++ b/services/graphql-server/src/graphql/router.test.js
@@ -11,9 +11,6 @@ describe('GraphQLRouter', () => {
 
     beforeEach(() => {
       config = {
-        siteServiceAddr: 'service:9999',
-        sensorServiceAddr: 'service:9999',
-        switchServiceAddr: 'service:9999',
         graphiQlEnabled: false
       }
 
@@ -31,12 +28,13 @@ describe('GraphQLRouter', () => {
         context: {},
         siteService: {},
         sensorService: {},
-        switchService: {}
+        switchService: {},
+        assetService: {}
       }
     })
 
     it('should create a new graphql router with defaults', () => {
-      const router = new GraphQLRouter(config, { tracer: options.tracer })
+      const router = new GraphQLRouter(config, { tracer: options.tracer, switchService: {}, assetService: {} })
       should.exist(router.router)
     })
     it('should create a new graphql router with provided options', () => {

--- a/services/graphql-server/src/graphql/schema.graphql
+++ b/services/graphql-server/src/graphql/schema.graphql
@@ -100,6 +100,7 @@ type Site {
   tags: [String!]!
   sensors: [Sensor!]!
   switches: [Switch!]!
+  assets: [Asset!]!
 }
 
 """

--- a/services/graphql-server/src/graphql/schema.graphql
+++ b/services/graphql-server/src/graphql/schema.graphql
@@ -1,6 +1,7 @@
 ## http://facebook.github.io/graphql
-## https://graphql.org/learn/schema
-## http://graphql.github.io/graphql-js
+## https://graphql.github.io/learn/schema
+## https://github.com/graphql/graphql-js
+## https://github.com/apollographql/graphql-tools
 
 schema {
   query: Query
@@ -61,7 +62,7 @@ type Mutation {
 }
 
 """
-SiteInput can be used for creating or updating a site.
+SiteInput is used for creating or updating a site.
 """
 input SiteInput {
   name: String!
@@ -85,7 +86,7 @@ type Site {
 }
 
 """
-SensorInput can be used for creating or updating a sensor.
+SensorInput is used for creating or updating a sensor.
 """
 input SensorInput {
   siteId: ID!
@@ -109,7 +110,7 @@ type Sensor {
 }
 
 """
-SwitchInput can be used for creating a switch.
+SwitchInput is used for creating a switch.
 """
 input SwitchInput {
   siteId: ID!
@@ -120,7 +121,7 @@ input SwitchInput {
 
 """
 Switch is the type for any kind of device that interacts with a site and alters it.
-Each switch has a set of pre-defined states and can be in one of the state at a time. 
+Each switch has a set of pre-defined states and can be in one of the state at a time.
 """
 type Switch {
   id: ID!

--- a/services/graphql-server/src/graphql/schema.graphql
+++ b/services/graphql-server/src/graphql/schema.graphql
@@ -36,6 +36,10 @@ type Query {
   switch(id: ID!): Switch
   "Retrieve all switches of a site."
   switches(siteId: ID!): [Switch!]
+  "Retrieve a single asset."
+  asset(id: ID!): Asset
+  "Retrieve all assets of a site."
+  assets(siteId: ID!): [Asset!]
 }
 
 type Mutation {
@@ -59,6 +63,19 @@ type Mutation {
   setSwitch(id: ID!, state: String!): Switch
   "Remove an existing switch."
   removeSwitch(id: ID!): Boolean
+
+  "Create a new alarm."
+  createAlarm(input: AlarmInput!): Alarm!
+  "Update an existing alarm."
+  updateAlarm(id: ID!, input: AlarmInput!): Alarm
+
+  "Create a new camera."
+  createCamera(input: CameraInput!): Camera!
+  "Update an existing camera."
+  updateCamera(id: ID!, input: CameraInput!): Camera
+
+  "Delete an existing asset."
+  deleteAsset(id: ID!): Boolean
 }
 
 """
@@ -129,4 +146,54 @@ type Switch {
   name: String!
   state: String!
   states: [String!]!
+}
+
+"""
+Asset is the generic type for any kind of asset associated with a site.
+Each asset has a unique id and also a unique serial number.
+"""
+interface Asset {
+  id: ID!
+  siteId: ID!
+  serialNo: String!
+}
+
+"""
+AlarmInput is used for creating or updating an alarm.
+"""
+input AlarmInput {
+  siteId: ID!
+  serialNo: String!
+  material: String
+}
+
+"""
+Alarm is the type for any kind of device for altering in a site.
+Each alarm is sensitive to one type of material and can detect changes to it.
+"""
+type Alarm implements Asset {
+  id: ID!
+  siteId: ID!
+  serialNo: String!
+  material: String
+}
+
+"""
+CameraInput is used for creating or updating a camera.
+"""
+input CameraInput {
+  siteId: ID!
+  serialNo: String!
+  resolution: Int
+}
+
+"""
+Camera is the type for any kind of camera for monitoring a site.
+Each camera has a resolution in which it can record the pictures.
+"""
+type Camera implements Asset {
+  id: ID!
+  siteId: ID!
+  serialNo: String!
+  resolution: Int
 }

--- a/services/graphql-server/src/server.js
+++ b/services/graphql-server/src/server.js
@@ -66,7 +66,7 @@ class Server {
       // Create and start a http server
       const server = http.createServer(this.app)
       server.listen(config.servicePort, () => {
-        this.logger.info(`Listening on port ${config.servicePort} ...`)
+        this.logger.info(`🚀 Listening on port ${config.servicePort} ...`)
       })
     } catch (err) {
       this.logger.fatal('Server errored:', err)

--- a/services/graphql-server/src/services/asset.js
+++ b/services/graphql-server/src/services/asset.js
@@ -71,17 +71,17 @@ class AssetService {
   getAssets (context, siteId) {
     return this.exec(context, 'get-assets', spanContext => {
       return Promise.resolve([
-        { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' },
+        { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'co' },
         { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
       ])
     })
   }
 
   createAlarm (context, input) {
-    this.logger.debug(`Received ${input}`)
+    this.logger.info('Received', input)
 
     return this.exec(context, 'create-alarm', spanContext => {
-      return Promise.resolve({ id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'smoke' })
+      return Promise.resolve({ id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'co' })
     })
   }
 
@@ -91,14 +91,8 @@ class AssetService {
     })
   }
 
-  deleteAlarm (context, id) {
-    return this.exec(context, 'delete-alarm', spanContext => {
-      return Promise.resolve(true)
-    })
-  }
-
   createCamera (context, input) {
-    this.logger.debug(`Received ${input}`)
+    this.logger.info('Received', input)
 
     return this.exec(context, 'create-camera', spanContext => {
       return Promise.resolve({ id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 })
@@ -107,12 +101,12 @@ class AssetService {
 
   updateCamera (context, id, input) {
     return this.exec(context, 'update-camera', spanContext => {
-      return Promise.resolve({ id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 })
+      return Promise.resolve({ id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 2073600 })
     })
   }
 
-  deleteCamera (context, id) {
-    return this.exec(context, 'delete-camera', spanContext => {
+  deleteAsset (context, id) {
+    return this.exec(context, 'delete-asset', spanContext => {
       return Promise.resolve(true)
     })
   }

--- a/services/graphql-server/src/services/asset.test.js
+++ b/services/graphql-server/src/services/asset.test.js
@@ -147,10 +147,6 @@ describe('AssetService', () => {
 
   })
 
-  describe('deleteAlarm', () => {
-
-  })
-
   describe('createCamera', () => {
 
   })
@@ -159,7 +155,7 @@ describe('AssetService', () => {
 
   })
 
-  describe('deleteCamera', () => {
+  describe('deleteAsset', () => {
 
   })
 })

--- a/services/graphql-server/src/services/asset.test.js
+++ b/services/graphql-server/src/services/asset.test.js
@@ -1,17 +1,22 @@
 /* eslint-env mocha */
 const { URL } = require('url')
+const nats = require('nats')
 const sinon = require('sinon')
 const should = require('should')
 const opentracing = require('opentracing')
 
 const AssetService = require('./asset')
 
+const expectedSubject = 'asset_service'
+const expectedOptions = {}
+const expectedTimeout = 1000
+
 describe('AssetService', () => {
   let logger
   let histogram, _histogram
   let summary, _summary
   let tracer, _tracer
-  let nats, _nats
+  let conn, _conn
   let config, options
   let service, _service
   let span, context
@@ -41,7 +46,7 @@ describe('AssetService', () => {
     _tracer = sinon.mock(tracer)
     _tracer.expects('inject').returns()
 
-    nats = {
+    conn = {
       publish () {},
       subscribe () {},
       request () {},
@@ -50,14 +55,14 @@ describe('AssetService', () => {
         url: new URL('nats://nats:4222')
       }
     }
-    _nats = sinon.mock(nats)
+    _conn = sinon.mock(conn)
 
     config = {
       servers: 'nats://nats:4222',
       user: 'client',
       pass: 'pass'
     }
-    options = { logger, histogram, summary, tracer, nats }
+    options = { logger, histogram, summary, tracer, conn }
 
     service = new AssetService(config, options)
     _service = sinon.mock(service)
@@ -70,18 +75,18 @@ describe('AssetService', () => {
     _histogram.restore()
     _summary.restore()
     _tracer.restore()
-    _nats.restore()
+    _conn.restore()
     _service.restore()
   })
 
   describe('constructor', () => {
     it('should create a new service with defaults', () => {
-      const service = new AssetService(config, { tracer: options.tracer, nats: options.nats })
+      const service = new AssetService(config, { tracer: options.tracer, conn: options.conn })
       should.exist(service.logger)
       should.exist(service.histogram)
       should.exist(service.summary)
       should.exist(service.tracer)
-      should.exist(service.nats)
+      should.exist(service.conn)
     })
     it('should create a new service with provided options', () => {
       const service = new AssetService(config, options)
@@ -89,7 +94,7 @@ describe('AssetService', () => {
       service.histogram.should.equal(options.histogram)
       service.summary.should.equal(options.summary)
       service.tracer.should.equal(options.tracer)
-      service.nats.should.equal(options.nats)
+      service.conn.should.equal(options.conn)
     })
   })
 
@@ -99,7 +104,7 @@ describe('AssetService', () => {
       span.operationName().should.equal(spanName)
       span.tags()[opentracing.Tags.SPAN_KIND].should.equal('requester')
       span.tags()[opentracing.Tags.PEER_SERVICE].should.equal('asset-service')
-      span.tags()[opentracing.Tags.PEER_ADDRESS].should.equal(nats.currentServer.url.host)
+      span.tags()[opentracing.Tags.PEER_ADDRESS].should.equal(conn.currentServer.url.host)
       span._logs[0].fields.event.should.equal(spanName)
       span._logs[0].fields.message.should.equal(logMessage)
     }
@@ -131,31 +136,937 @@ describe('AssetService', () => {
     })
   })
 
-  describe('getAsset', () => {
-
-  })
-
-  describe('getAssets', () => {
-
-  })
-
   describe('createAlarm', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('create-alarm')
 
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const input = { siteId: '1111-1111', serialNo: '1001', material: 'co' }
+      const requestMsg = JSON.stringify({ kind: 'createAlarm', span: '{}', input })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.createAlarm(context, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const input = { siteId: '1111-1111', serialNo: '1001', material: 'co' }
+      const requestMsg = JSON.stringify({ kind: 'createAlarm', span: '{}', input })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.createAlarm(context, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const input = { siteId: '1111-1111', serialNo: '1001', material: 'co' }
+      const requestMsg = JSON.stringify({ kind: 'createAlarm', span: '{}', input })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.createAlarm(context, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const input = { siteId: '1111-1111', serialNo: '1001', material: 'co' }
+      const alarm = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'co' }
+      const requestMsg = JSON.stringify({ kind: 'createAlarm', span: '{}', input })
+      const responseMsg = JSON.stringify({ kind: 'createAlarm', alarm })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.createAlarm(context, input).then(result => {
+        result.should.eql(alarm)
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
+  })
+
+  describe('allAlarm', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('all-alarm')
+
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const siteId = '1111-1111'
+      const requestMsg = JSON.stringify({ kind: 'allAlarm', span: '{}', siteId })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.allAlarm(context, siteId).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const siteId = '1111-1111'
+      const requestMsg = JSON.stringify({ kind: 'allAlarm', span: '{}', siteId })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.allAlarm(context, siteId).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const siteId = '1111-1111'
+      const requestMsg = JSON.stringify({ kind: 'allAlarm', span: '{}', siteId })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.allAlarm(context, siteId).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const siteId = '1111-1111'
+      const alarms = [{ id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'co' }]
+      const requestMsg = JSON.stringify({ kind: 'allAlarm', span: '{}', siteId })
+      const responseMsg = JSON.stringify({ kind: 'allAlarm', alarms })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.allAlarm(context, siteId).then(result => {
+        result.should.eql(alarms)
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
+  })
+
+  describe('getAlarm', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('get-alarm')
+
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const id = 'aaaa-aaaa'
+      const requestMsg = JSON.stringify({ kind: 'getAlarm', span: '{}', id })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.getAlarm(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const id = 'aaaa-aaaa'
+      const requestMsg = JSON.stringify({ kind: 'getAlarm', span: '{}', id })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.getAlarm(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const id = 'aaaa-aaaa'
+      const requestMsg = JSON.stringify({ kind: 'getAlarm', span: '{}', id })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.getAlarm(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const id = 'aaaa-aaaa'
+      const alarm = { id: 'aaaa-aaaa', siteId: '1111-1111', serialNo: '1001', material: 'co' }
+      const requestMsg = JSON.stringify({ kind: 'getAlarm', span: '{}', id })
+      const responseMsg = JSON.stringify({ kind: 'getAlarm', alarm })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.getAlarm(context, id).then(result => {
+        result.should.eql(alarm)
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
   })
 
   describe('updateAlarm', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('update-alarm')
 
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const id = 'aaaa-aaaa'
+      const input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+      const requestMsg = JSON.stringify({ kind: 'updateAlarm', span: '{}', id, input })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.updateAlarm(context, id, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const id = 'aaaa-aaaa'
+      const input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+      const requestMsg = JSON.stringify({ kind: 'updateAlarm', span: '{}', id, input })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.updateAlarm(context, id, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const id = 'aaaa-aaaa'
+      const input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+      const requestMsg = JSON.stringify({ kind: 'updateAlarm', span: '{}', id, input })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.updateAlarm(context, id, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const id = 'aaaa-aaaa'
+      const input = { siteId: '1111-1111', serialNo: '1001', material: 'smoke' }
+      const requestMsg = JSON.stringify({ kind: 'updateAlarm', span: '{}', id, input })
+      const responseMsg = JSON.stringify({ kind: 'updateAlarm', updated: true })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.updateAlarm(context, id, input).then(result => {
+        result.should.be.true()
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
+  })
+
+  describe('deleteAlarm', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('delete-alarm')
+
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const id = 'aaaa-aaaa'
+      const requestMsg = JSON.stringify({ kind: 'deleteAlarm', span: '{}', id })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.deleteAlarm(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const id = 'aaaa-aaaa'
+      const requestMsg = JSON.stringify({ kind: 'deleteAlarm', span: '{}', id })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.deleteAlarm(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const id = 'aaaa-aaaa'
+      const requestMsg = JSON.stringify({ kind: 'deleteAlarm', span: '{}', id })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.deleteAlarm(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const id = 'aaaa-aaaa'
+      const requestMsg = JSON.stringify({ kind: 'deleteAlarm', span: '{}', id })
+      const responseMsg = JSON.stringify({ kind: 'deleteAlarm', deleted: true })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.deleteAlarm(context, id).then(result => {
+        result.should.be.true()
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
   })
 
   describe('createCamera', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('create-camera')
 
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+      const requestMsg = JSON.stringify({ kind: 'createCamera', span: '{}', input })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.createCamera(context, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+      const requestMsg = JSON.stringify({ kind: 'createCamera', span: '{}', input })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.createCamera(context, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+      const requestMsg = JSON.stringify({ kind: 'createCamera', span: '{}', input })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.createCamera(context, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const input = { siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+      const camera = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+      const requestMsg = JSON.stringify({ kind: 'createCamera', span: '{}', input })
+      const responseMsg = JSON.stringify({ kind: 'createCamera', camera })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.createCamera(context, input).then(result => {
+        result.should.eql(camera)
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
+  })
+
+  describe('allCamera', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('all-camera')
+
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const siteId = '1111-1111'
+      const requestMsg = JSON.stringify({ kind: 'allCamera', span: '{}', siteId })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.allCamera(context, siteId).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const siteId = '1111-1111'
+      const requestMsg = JSON.stringify({ kind: 'allCamera', span: '{}', siteId })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.allCamera(context, siteId).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const siteId = '1111-1111'
+      const requestMsg = JSON.stringify({ kind: 'allCamera', span: '{}', siteId })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.allCamera(context, siteId).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const siteId = '1111-1111'
+      const cameras = [{ id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }]
+      const requestMsg = JSON.stringify({ kind: 'allCamera', span: '{}', siteId })
+      const responseMsg = JSON.stringify({ kind: 'allCamera', cameras })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.allCamera(context, siteId).then(result => {
+        result.should.eql(cameras)
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
+  })
+
+  describe('getCamera', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('get-camera')
+
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const id = 'bbbb-bbbb'
+      const requestMsg = JSON.stringify({ kind: 'getCamera', span: '{}', id })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.getCamera(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const id = 'bbbb-bbbb'
+      const requestMsg = JSON.stringify({ kind: 'getCamera', span: '{}', id })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.getCamera(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const id = 'bbbb-bbbb'
+      const requestMsg = JSON.stringify({ kind: 'getCamera', span: '{}', id })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.getCamera(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const id = 'bbbb-bbbb'
+      const camera = { id: 'bbbb-bbbb', siteId: '1111-1111', serialNo: '2001', resolution: 921600 }
+      const requestMsg = JSON.stringify({ kind: 'getCamera', span: '{}', id })
+      const responseMsg = JSON.stringify({ kind: 'getCamera', camera })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.getCamera(context, id).then(result => {
+        result.should.eql(camera)
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
   })
 
   describe('updateCamera', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('update-camera')
 
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const id = 'bbbb-bbbb'
+      const input = { siteId: '1111-1111', serialNo: '2001', resolution: 1920000 }
+      const requestMsg = JSON.stringify({ kind: 'updateCamera', span: '{}', id, input })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.updateCamera(context, id, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const id = 'bbbb-bbbb'
+      const input = { siteId: '1111-1111', serialNo: '2001', resolution: 1920000 }
+      const requestMsg = JSON.stringify({ kind: 'updateCamera', span: '{}', id, input })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.updateCamera(context, id, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const id = 'bbbb-bbbb'
+      const input = { siteId: '1111-1111', serialNo: '2001', resolution: 1920000 }
+      const requestMsg = JSON.stringify({ kind: 'updateCamera', span: '{}', id, input })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.updateCamera(context, id, input).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const id = 'bbbb-bbbb'
+      const input = { siteId: '1111-1111', serialNo: '2001', resolution: 1920000 }
+      const requestMsg = JSON.stringify({ kind: 'updateCamera', span: '{}', id, input })
+      const responseMsg = JSON.stringify({ kind: 'updateCamera', updated: true })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.updateCamera(context, id, input).then(result => {
+        result.should.be.true()
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
   })
 
-  describe('deleteAsset', () => {
+  describe('deleteCamera', () => {
+    beforeEach(() => {
+      _service.expects('exec').callsFake((ctx, name, func) => {
+        ctx.should.eql(context)
+        name.should.equal('delete-camera')
 
+        const spanContext = `{}`
+        return func(spanContext)
+      })
+    })
+
+    afterEach(() => {
+      _service.verify()
+      _service.restore()
+    })
+
+    it('should reject with error when request is timed out', done => {
+      const id = 'bbbb-bbbb'
+      const requestMsg = JSON.stringify({ kind: 'deleteCamera', span: '{}', id })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(new nats.NatsError('timeout'))
+      })
+      service.deleteCamera(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response is not json', done => {
+      const id = 'bbbb-bbbb'
+      const requestMsg = JSON.stringify({ kind: 'deleteCamera', span: '{}', id })
+      const responseMsg = `{ invalid json }`
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.deleteCamera(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should reject with error when response has an expected type', done => {
+      const id = 'bbbb-bbbb'
+      const requestMsg = JSON.stringify({ kind: 'deleteCamera', span: '{}', id })
+      const responseMsg = JSON.stringify({ kind: 'invalidKind' })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.deleteCamera(context, id).catch(err => {
+        should.exist(err)
+        _conn.verify()
+        _conn.restore()
+        done()
+      })
+    })
+
+    it('should resolve successfully when response has the expected type', done => {
+      const id = 'bbbb-bbbb'
+      const requestMsg = JSON.stringify({ kind: 'deleteCamera', span: '{}', id })
+      const responseMsg = JSON.stringify({ kind: 'deleteCamera', deleted: true })
+      _conn.expects('requestOne').callsFake((subject, message, options, timeout, callback) => {
+        subject.should.equal(expectedSubject)
+        message.should.equal(requestMsg)
+        options.should.eql(expectedOptions)
+        timeout.should.equal(expectedTimeout)
+        callback(responseMsg)
+      })
+      service.deleteCamera(context, id).then(result => {
+        result.should.be.true()
+        _conn.verify()
+        _conn.restore()
+        done()
+      }).catch(done)
+    })
   })
 })

--- a/services/graphql-server/src/services/sensor.js
+++ b/services/graphql-server/src/services/sensor.js
@@ -22,8 +22,8 @@ class SensorService {
   }
 
   async exec (context, name, func) {
-    let result, err
-    let latency
+    let err, result
+    let startTime, latency
 
     // https://opentracing-javascript.surge.sh/interfaces/spanoptions.html
     // https://github.com/opentracing/specification/blob/master/semantic_conventions.md
@@ -37,12 +37,13 @@ class SensorService {
 
     // Core functionality
     try {
-      const startTime = Date.now()
+      startTime = Date.now()
       result = await func(headers)
-      latency = (Date.now() - startTime) / 1000
     } catch (e) {
       err = e
       this.logger.error(err)
+    } finally {
+      latency = (Date.now() - startTime) / 1000
     }
 
     // Metrics
@@ -60,7 +61,6 @@ class SensorService {
     if (err) {
       throw err
     }
-
     return result
   }
 

--- a/services/graphql-server/src/services/site.js
+++ b/services/graphql-server/src/services/site.js
@@ -22,8 +22,8 @@ class SiteService {
   }
 
   async exec (context, name, func) {
-    let result, err
-    let latency
+    let err, result
+    let startTime, latency
 
     // https://opentracing-javascript.surge.sh/interfaces/spanoptions.html
     // https://github.com/opentracing/specification/blob/master/semantic_conventions.md
@@ -37,12 +37,13 @@ class SiteService {
 
     // Core functionality
     try {
-      const startTime = Date.now()
+      startTime = Date.now()
       result = await func(headers)
-      latency = (Date.now() - startTime) / 1000
     } catch (e) {
       err = e
       this.logger.error(err)
+    } finally {
+      latency = (Date.now() - startTime) / 1000
     }
 
     // Metrics
@@ -60,7 +61,6 @@ class SiteService {
     if (err) {
       throw err
     }
-
     return result
   }
 

--- a/services/graphql-server/src/services/switch.js
+++ b/services/graphql-server/src/services/switch.js
@@ -20,8 +20,8 @@ class SwitchService {
   }
 
   async exec (context, name, func) {
-    let result, err
-    let latency
+    let err, result
+    let startTime, latency
 
     // https://opentracing-javascript.surge.sh/interfaces/spanoptions.html
     // https://github.com/opentracing/specification/blob/master/semantic_conventions.md
@@ -38,12 +38,13 @@ class SwitchService {
 
     // Core functionality
     try {
-      const startTime = Date.now()
+      startTime = Date.now()
       result = await func(metadata)
-      latency = (Date.now() - startTime) / 1000
     } catch (e) {
       err = e
       this.logger.error(err)
+    } finally {
+      latency = (Date.now() - startTime) / 1000
     }
 
     // Metrics
@@ -61,7 +62,6 @@ class SwitchService {
     if (err) {
       throw err
     }
-
     return result
   }
 

--- a/services/graphql-server/test/mock/nats/config.js
+++ b/services/graphql-server/test/mock/nats/config.js
@@ -3,16 +3,12 @@ const fs = require('fs')
 const defaultNatsServers = 'nats://localhost:4222'
 const defaultNatsUser = 'client'
 const defaultNatsPassword = 'pass'
-const defaultAssetSubject = 'asset_service'
-const defaultAssetQueue = 'workers'
 
 class Config {
   constructor () {
     this.natsServers = this._getValue('NATS_SERVERS', defaultNatsServers).split(',')
     this.natsUser = this._getValue('NATS_USER', defaultNatsUser)
     this.natsPassword = this._getValue('NATS_PASSWORD', defaultNatsPassword)
-    this.assetSubject = this._getValue('ASSET_SUBJECT', defaultAssetSubject)
-    this.assetQueue = this._getValue('ASSET_QUEUE', defaultAssetQueue)
   }
 
   _getValue (name, defaultValue) {

--- a/services/graphql-server/test/mock/nats/index.js
+++ b/services/graphql-server/test/mock/nats/index.js
@@ -1,30 +1,176 @@
 const nats = require('nats')
 const chalk = require('chalk')
+const uuidv4 = require('uuid/v4')
 
 const Config = require('./config')
 
+const subject = 'asset_service'
+const queue = 'workers'
+
 class MockAssetService {
   constructor (config) {
-    this.nats = nats.connect({
+    this.store = {
+      alarms: [],
+      cameras: []
+    }
+    this.conn = nats.connect({
       servers: config.natsServers,
       user: config.natsUser,
       pass: config.natsPassword
     })
-    this.subject = config.assetSubject
-    this.queue = config.assetQueue
+  }
+
+  createAlarm (request, reply) {
+    const id = uuidv4()
+    const alarm = Object.assign({ id }, request.input)
+    const response = { kind: request.kind, alarm }
+    const msg = JSON.stringify(response)
+    this.conn.publish(reply, msg)
+    this.store.alarms.push(alarm)
+
+    console.log(chalk.green(`Sent message ${msg}`))
+  }
+
+  allAlarm (request, reply) {
+    const alarms = this.store.alarms.filter(a => a.siteId === request.siteId)
+    const response = { kind: request.kind, alarms }
+    const msg = JSON.stringify(response)
+    this.conn.publish(reply, msg)
+
+    console.log(chalk.green(`Sent message ${msg}`))
+  }
+
+  getAlarm (request, reply) {
+    const alarm = this.store.alarms.find(a => a.id === request.id)
+    const response = { kind: request.kind, alarm }
+    const msg = JSON.stringify(response)
+    this.conn.publish(reply, msg)
+
+    console.log(chalk.green(`Sent message ${msg}`))
+  }
+
+  updateAlarm (request, reply) {
+    const alarm = this.store.alarms.find(a => a.id === request.id)
+    Object.assign(alarm, request.input)
+    const response = { kind: request.kind, updated: true }
+    const msg = JSON.stringify(response)
+    this.conn.publish(reply, msg)
+
+    console.log(chalk.green(`Sent message ${msg}`))
+  }
+
+  deleteAlarm (request, reply) {
+    this.store.alarms = this.store.alarms.filter(a => a.id !== request.id)
+    const response = { kind: request.kind, deleted: true }
+    const msg = JSON.stringify(response)
+    this.conn.publish(reply, msg)
+
+    console.log(chalk.green(`Sent message ${msg}`))
+  }
+
+  createCamera (request, reply) {
+    const id = uuidv4()
+    const camera = Object.assign({ id }, request.input)
+    const response = { kind: request.kind, camera }
+    const msg = JSON.stringify(response)
+
+    this.store.cameras.push(camera)
+    this.conn.publish(reply, msg)
+
+    console.log(chalk.green(`Sent message ${msg}`))
+  }
+
+  allCamera (request, reply) {
+    const cameras = this.store.cameras.filter(c => c.siteId === request.siteId)
+    const response = { kind: request.kind, cameras }
+    const msg = JSON.stringify(response)
+    this.conn.publish(reply, msg)
+
+    console.log(chalk.green(`Sent message ${msg}`))
+  }
+
+  getCamera (request, reply) {
+    const camera = this.store.cameras.find(c => c.id === request.id)
+    const response = { kind: request.kind, camera }
+    const msg = JSON.stringify(response)
+    this.conn.publish(reply, msg)
+
+    console.log(chalk.green(`Sent message ${msg}`))
+  }
+
+  updateCamera (request, reply) {
+    const camera = this.store.cameras.find(c => c.id === request.id)
+    Object.assign(camera, request.input)
+    const response = { kind: request.kind, updated: true }
+    const msg = JSON.stringify(response)
+    this.conn.publish(reply, msg)
+
+    console.log(chalk.green(`Sent message ${msg}`))
+  }
+
+  deleteCamera (request, reply) {
+    this.store.cameras = this.store.cameras.filter(c => c.id !== request.id)
+    const response = { kind: request.kind, deleted: true }
+    const msg = JSON.stringify(response)
+    this.conn.publish(reply, msg)
+
+    console.log(chalk.green(`Sent message ${msg}`))
   }
 
   start () {
-    console.log(chalk.green(`Mock NATS API Service started ...`))
+    console.log(chalk.green('Mock NATS API Service started ...'))
 
-    this.subscription = this.nats.subscribe(this.subject, { queue: this.queue }, msg => {
+    this.sid = this.conn.subscribe(subject, { queue }, (msg, reply) => {
       console.log(chalk.blue(`Received message ${msg}`))
+
+      let request
+
+      try {
+        request = JSON.parse(msg)
+      } catch (err) {
+        console.log(chalk.red(`Invalid request ${msg}`))
+      }
+
+      switch (request.kind) {
+        case 'createAlarm':
+          this.createAlarm(request, reply)
+          break
+        case 'allAlarm':
+          this.allAlarm(request, reply)
+          break
+        case 'getAlarm':
+          this.getAlarm(request, reply)
+          break
+        case 'updateAlarm':
+          this.updateAlarm(request, reply)
+          break
+        case 'deleteAlarm':
+          this.deleteAlarm(request, reply)
+          break
+        case 'createCamera':
+          this.createCamera(request, reply)
+          break
+        case 'allCamera':
+          this.allCamera(request, reply)
+          break
+        case 'getCamera':
+          this.getCamera(request, reply)
+          break
+        case 'updateCamera':
+          this.updateCamera(request, reply)
+          break
+        case 'deleteCamera':
+          this.deleteCamera(request, reply)
+          break
+        default:
+          console.log(chalk.yellow(`Unknown request ${request.kind}`))
+      }
     })
   }
 
   stop () {
-    this.nats.unsubscribe(this.subscription)
-    this.nats.close()
+    this.conn.unsubscribe(this.sid)
+    this.conn.close()
   }
 }
 


### PR DESCRIPTION
This PR implements communication and service requests to `asset-service` in `graphql-server`. It also updates the **GraphQL** schema for adding asset queries and mutations.