### PR TITLE
graphql-server: fix double meta logging

### DIFF
--- a/services/graphql-server/src/utils/logger.js
+++ b/services/graphql-server/src/utils/logger.js
@@ -1,3 +1,4 @@
+const os = require('os')
 const winston = require('winston')
 
 const levels = { fatal: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 }
@@ -55,26 +56,25 @@ class Logger {
   constructor (module, options) {
     options = options || {}
     this.winston = options.winston || Logger.getWinstonLogger()
-    this.metadata = Object.assign({ pid: process.pid }, Logger.metadata, options.metadata, module ? { module } : {})
+    this.metadata = Object.assign({}, Logger.metadata, options.metadata, module ? { module } : {})
   }
 
   _log (level, args) {
     let values = []
-    let metadata = Object.assign({}, this.metadata)
+    let meta = Object.assign({}, this.metadata)
 
-    // Make sure all objects are logged as metadata
     for (let arg of args) {
       if (arg instanceof Error) {
         values.push(arg.message)
-        Object.assign(metadata, { error: arg })
+        Object.assign(meta, { error: arg })
       } else if (typeof arg === 'object') {
-        Object.assign(metadata, arg)
+        Object.assign(meta, arg)
       } else {
         values.push(arg)
       }
     }
 
-    this.winston.log(level, values.join(' '), metadata)
+    this.winston.log({ level, meta, message: values.join(' ') })
   }
 
   trace () {
@@ -102,6 +102,9 @@ class Logger {
   }
 }
 
-Logger.metadata = {}
+Logger.metadata = {
+  pid: process.pid,
+  platform: os.platform()
+}
 
 module.exports = Logger

--- a/services/graphql-server/src/utils/logger.test.js
+++ b/services/graphql-server/src/utils/logger.test.js
@@ -5,10 +5,6 @@ const Logger = require('./logger')
 
 describe('Logger', () => {
   describe('addMetadata', () => {
-    afterEach(() => {
-      Logger.metadata = {}
-    })
-
     it('should add properties to metadata', () => {
       Logger.addMetadata({ account: 'dev', environment: 'test' })
       Logger.metadata.account.should.equal('dev')
@@ -69,7 +65,6 @@ describe('Logger', () => {
 
   describe('constructor', () => {
     afterEach(() => {
-      Logger.metadata = {}
       Logger.winston = null
     })
 
@@ -101,7 +96,6 @@ describe('Logger', () => {
     const origLogLevel = process.env.LOG_LEVEL
 
     afterEach(() => {
-      Logger.metadata = {}
       Logger.winston = null
       delete process.env.LOG_LEVEL
     })


### PR DESCRIPTION
Resolves #100

  - [x] `graphql-server` logger will no longer log metadata both in the log object and on `meta` property.
  - [x] `pid` is now logged as a metadata on every log (including `express-winston` logs)