### PR TITLE
Update Workflows

### DIFF
--- a/.github/workflows/asset.yml
+++ b/.github/workflows/asset.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 2
       - name: Linting
         uses: moorara/actions/go-lint@master
         with:

--- a/.github/workflows/sensor.yml
+++ b/.github/workflows/sensor.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 2
       - name: Linting
         uses: moorara/actions/go-lint@master
         with:

--- a/.github/workflows/switch.yml
+++ b/.github/workflows/switch.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 2
       - name: Linting
         uses: moorara/actions/go-lint@master
         with:


### PR DESCRIPTION
For `golangci-lint` to work with `--new`, the `checkout` action needs be fetch with a higher depth.