### PR TITLE
Fix graphql-service unit tests

### DIFF
--- a/services/graphql/src/server.test.js
+++ b/services/graphql/src/server.test.js
@@ -9,6 +9,11 @@ const Server = require('./server')
 
 describe('Server', () => {
   describe('constructor', () => {
+    afterEach(() => {
+      // Clear default metrics register, so subsequent tests will not fail.
+      promClient.register.clear()
+    })
+
     it('should create a new server with defaults', () => {
       const server = new Server()
       should.exist(server.configProvider)

--- a/services/graphql/src/utils/metrics.test.js
+++ b/services/graphql/src/utils/metrics.test.js
@@ -10,6 +10,11 @@ describe('Metrics', () => {
   describe('constructor', () => {
     let metrics
 
+    afterEach(() => {
+      // Clear default metrics register, so subsequent tests will not fail.
+      promClient.register.clear()
+    })
+
     it('should create new metrics with global registry', () => {
       metrics = new Metrics()
       should.exist(metrics.register)


### PR DESCRIPTION

  - [x] Clearing the default _register_ for Prometheus client after the tests.